### PR TITLE
Export the module and make it possible to pass option to the constructor

### DIFF
--- a/src/Zoomable.js
+++ b/src/Zoomable.js
@@ -57,9 +57,9 @@ const defaults = {
 };
 
 class Zoomable {
-  constructor(element) {
+  constructor(element, options) {
     this.element = element;
-    this.config = Object.assign({}, defaults, { element: element });
+    this.config = Object.assign({}, defaults, options, { element: element });
 
     // bind element to do things when the image has loaded
     onImageLoad.call(element);
@@ -310,4 +310,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let element = elements[i];
     element.__zoomable__ = new Zoomable(element);
   }
+
 });
+
+export default Zoomable;


### PR DESCRIPTION
_PR in progress, need feedback._

This Expose the Zoomable class publicly. The goal is to be able to import it directly from another es6 project. Then we could just:

``` js
import Zoomable from 'minimal-lightbox';

new Zoomable(document.getElementById('my-image'), options);
```

Useful if we want for exemple to preload images or if we add images dynamically.
### The problems are:
- In order to import it like that, the `main` attribute in `package.json` need to point to `src/Zoomable.js` but  we then loose the ability to wiredep the compiled version for exemple. I do think we should make the move, it's more future proof, and you could just manually add the compiled version with script tags in your html, that does not repose on the `main` attribute.
- Also, I'm thinking that the options could **also** been read from `data-attributes`, that way you just have to add the script and it will be configured and don't need another javascript to have custom configuration.
- Finally, if I want to manually bind the zoom, I will not add `data-action=zoom` but then some styles use that as a selector. I think we should remove the reference to data-action in the css and replace it with a class that will be added by the constructor.

---

**tl;dr:** make it possible to use the plugin in 2 different ways:
- `new Zoomable(element, options)`

**or**  
- `<img src='image.jpg' data-action="zoom" data-ignore-scroll="false">`

_ref: #6_
